### PR TITLE
Fix camera capture and add editing dialog

### DIFF
--- a/Cardify-LoginBase/app/src/main/java/com/example/cardify/ui/screens/AddAutoClassifyScreen.kt
+++ b/Cardify-LoginBase/app/src/main/java/com/example/cardify/ui/screens/AddAutoClassifyScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,6 +56,7 @@ fun AddAutoClassifyScreen(
     val uiState by viewModel.uiState.collectAsState()
     val tokenManager = TokenManager(LocalContext.current)
     val token = tokenManager.getToken() ?: ""
+    var showEditDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.analyzeCardImage(capturedImage, token)
@@ -131,6 +134,12 @@ fun AddAutoClassifyScreen(
                                 DetailItem("전화번호", uiState.card.phone)
                                 DetailItem("이메일", uiState.card.email)
                                 DetailItem("SNS", uiState.card.sns)
+                                Button(
+                                    onClick = { showEditDialog = true },
+                                    modifier = Modifier.align(Alignment.End)
+                                ) {
+                                    Text("정보 수정")
+                                }
                             }
                         }
 
@@ -169,6 +178,17 @@ fun AddAutoClassifyScreen(
                                     )
                                 }
                             }
+                        }
+
+                        if (showEditDialog) {
+                            EditCardScreen(
+                                card = uiState.card,
+                                onSave = { updated ->
+                                    viewModel.updateCardInfo(updated)
+                                    showEditDialog = false
+                                },
+                                onDismiss = { showEditDialog = false }
+                            )
                         }
                     }
                 }

--- a/Cardify-LoginBase/app/src/main/java/com/example/cardify/ui/screens/AddFromCameraScreen.kt
+++ b/Cardify-LoginBase/app/src/main/java/com/example/cardify/ui/screens/AddFromCameraScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
-import androidx.core.net.toUri
 import androidx.navigation.NavController
 import com.example.cardify.navigation.Screen
 import java.io.File
@@ -56,17 +55,6 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.Executors
-
-private fun createImageFile(context: Context): File {
-    val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
-    val fileName = "JPEG_${timestamp}_"
-    val storageDir = context.getExternalFilesDir(null)
-    return File.createTempFile(
-        fileName,
-        ".jpg",
-        storageDir
-    )
-}
 
 @RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
@@ -224,9 +212,7 @@ fun CameraCaptureView(
                         override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
                             try {
                                 // Convert the saved file to a Bitmap
-                                val inputStream = context.contentResolver.openInputStream(photoFile.toUri())
-                                val bitmap = BitmapFactory.decodeStream(inputStream)
-                                inputStream?.close()
+                                val bitmap = BitmapFactory.decodeFile(photoFile.absolutePath)
 
                                 if (bitmap != null) {
                                     onImageCaptured(bitmap)
@@ -268,4 +254,4 @@ fun createImageFile(context: Context): File {
         ".jpg",
         storageDir
     )
-}}
+}


### PR DESCRIPTION
## Summary
- fix camera capture crash by decoding file directly
- remove duplicate createImageFile
- add edit card info button after OCR
- show EditCardScreen dialog to update recognized data

## Testing
- `bash gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452281d834832fba49716c358ce6d5